### PR TITLE
Inject BeanContainer instead of BeanManager to support CDI lite

### DIFF
--- a/livecoding-eventsourcing-cqrs/pom.xml
+++ b/livecoding-eventsourcing-cqrs/pom.xml
@@ -54,6 +54,7 @@
 		<archunit.version>0.23.1</archunit.version>
 		<equalsverifier.version>3.10.1</equalsverifier.version>
 		<weld-junit5.version>4.0.0.Final</weld-junit5.version>
+		<weld-se-core.version>5.1.0.Final</weld-se-core.version>
 		<mockito.version>4.8.0</mockito.version>
 		<hamcrest.version>2.2</hamcrest.version>
 		<junit-jupiter.version>5.9.0</junit-jupiter.version>
@@ -113,6 +114,12 @@
 			<scope>test</scope>
 		</dependency>
 
+         <dependency>
+            <groupId>org.jboss.weld.se</groupId>
+            <artifactId>weld-se-core</artifactId>
+            <version>${weld-se-core.version}</version>
+         </dependency>
+         
 		<!-- Test JSON-P (Processing) Provider -->
 		<dependency>
     		<groupId>org.glassfish</groupId>

--- a/livecoding-eventsourcing-cqrs/src/main/java/org/joht/livecoding/eventsourcing/infrastructure/axon/AxonConfiguration.java
+++ b/livecoding-eventsourcing-cqrs/src/main/java/org/joht/livecoding/eventsourcing/infrastructure/axon/AxonConfiguration.java
@@ -18,6 +18,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Produces;
 import jakarta.enterprise.inject.spi.BeanContainer;
 import jakarta.enterprise.inject.spi.CDI;
+import jakarta.inject.Inject;
 
 /**
  * Provides selected tools of the AxonFramework and their configuration for the use with CDI.
@@ -25,14 +26,15 @@ import jakarta.enterprise.inject.spi.CDI;
 @ApplicationScoped
 public class AxonConfiguration {
 
+	@Inject
+	BeanContainer beanContainer;
+	
 	private Configuration configuration;
 
 	@PostConstruct
 	protected void startUp() {
 		Configurer configurer = DefaultConfigurer.defaultConfiguration();
 		querySideEventProcessing(configurer);
-		//@Inject BeanContainer doesn't seem to work with weld-junit5 for now (2022-09)
-		BeanContainer beanContainer = CDI.current().getBeanContainer();
 		AxonComponentDiscovery.ofBeanContainer(beanContainer).addDiscoveredComponentsTo(configurer);
 		configuration = configurer.configureEmbeddedEventStore(this::eventStorageEngine).buildConfiguration();
 		configuration.start();


### PR DESCRIPTION
**Update 2022-10-14:**
The problem is solved in version `5.1.0.Final` of `weld-se-core` and CDI lite support using BeanContainer works as expected.

**Problem before the update:**
Currently, adding 
```java
@Inject
BeanContainer beanContainer;
```
in [AxonConfiguration.java](https://github.com/JohT/livecoding/blob/9002e885019aafb457d6149330b95b4bf95e4162/livecoding-eventsourcing-cqrs/src/main/java/org/joht/livecoding/eventsourcing/infrastructure/axon/AxonConfiguration.java#L30) leads to the following exception:
```
org.jboss.weld.exceptions.DeploymentException: WELD-001408: Unsatisfied dependencies for type BeanContainer with qualifiers @Default
  at injection point [BackedAnnotatedField] @Inject org.joht.livecoding.eventsourcing.infrastructure.axon.AxonConfiguration.beanContainer
  at org.joht.livecoding.eventsourcing.infrastructure.axon.AxonConfiguration.beanContainer(AxonConfiguration.java:0)

	at org.jboss.weld.bootstrap.Validator.validateInjectionPointForDeploymentProblems(Validator.java:367)
	at org.jboss.weld.bootstrap.Validator.validateInjectionPoint(Validator.java:285)
	at org.jboss.weld.bootstrap.Validator.validateGeneralBean(Validator.java:141)
	at org.jboss.weld.bootstrap.Validator.validateRIBean(Validator.java:162)
	at org.jboss.weld.bootstrap.Validator.validateBean(Validator.java:515)
	at org.jboss.weld.bootstrap.Validator.validateBeans(Validator.java:501)
	at org.jboss.weld.bootstrap.Validator.validateDeployment(Validator.java:476)
	at org.jboss.weld.bootstrap.WeldStartup.validateBeans(WeldStartup.java:492)
	at org.jboss.weld.bootstrap.WeldBootstrap.validateBeans(WeldBootstrap.java:94)
	at org.jboss.weld.environment.se.Weld.initialize(Weld.java:826)
	at org.jboss.weld.junit.AbstractWeldInitiator.initWeldContainer(AbstractWeldInitiator.java:536)
	at org.jboss.weld.junit5.WeldInitiator.initWeld(WeldInitiator.java:193)
	at org.jboss.weld.junit5.WeldJunit5Extension.startWeldContainerIfAppropriate(WeldJunit5Extension.java:246)
	at org.jboss.weld.junit5.WeldJunit5Extension.beforeEach(WeldJunit5Extension.java:218)
```

See [pipeline log](https://github.com/JohT/livecoding/actions/runs/3078156055/jobs/4973524746) for more details.